### PR TITLE
Develop

### DIFF
--- a/bin/adjust/sc_regress_out.py
+++ b/bin/adjust/sc_regress_out.py
@@ -34,6 +34,15 @@ parser.add_argument(
     help="Variable to regress out. To regress multiple variables, add that many -v arguments. Used when running 'regress_out"
 )
 
+parser.add_argument(
+    "-j", "--n-jobs",
+    type=int,
+    action="store",
+    dest="n_jobs",
+    default=1,
+    help="The number of jobs. When set to None, automatically uses the number of cores."
+)
+
 args = parser.parse_args()
 
 # Define the arguments properly
@@ -53,7 +62,11 @@ except IOError:
 
 if args.method == 'linear_regression':
     # regress out variables (e.g.: total counts per cell and the percentage of mitochondrial genes expressed)
-    sc.pp.regress_out(adata, args.vars_to_regress_out)
+    sc.pp.regress_out(
+        adata=adata,
+        keys=args.vars_to_regress_out,
+        n_jobs=args.n_jobs
+    )
 else:
     raise Exception("VSN ERROR: Method does not exist.")
 

--- a/bin/cluster/sc_clustering.py
+++ b/bin/cluster/sc_clustering.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import scanpy as sc
+import numpy as np
 
 parser = argparse.ArgumentParser(
     description='',
@@ -75,6 +76,13 @@ def check_neighborhood_graph_exists(adata):
         raise Exception(
             "The neighborhood graph of observations has not been computed.")
 
+
+def check_no_single_cluster(adata, method, resolution):
+    num_clusters = len(np.unique(adata.obs[method]))
+
+    if num_clusters == 1:
+        raise Exception(f"Single cluster found when running clustering algorithm {method} with resolution {resolution}. Please remove this one from params.sc.scanpy.clustering.resolutions.")
+
 #
 # Clustering the data
 #
@@ -100,6 +108,12 @@ elif args.method.lower() == "leiden":
     )
 else:
     raise Exception("VSN ERROR: The given clustering algorithm {} does not exist or is not implemeted.".format(args.method))
+
+check_no_single_cluster(
+    adata=adata,
+    method=args.method,
+    resolution=args.resolution
+)
 
 # I/O
 adata.write_h5ad("{}.h5ad".format(FILE_PATH_OUT_BASENAME))

--- a/bin/cluster/sc_clustering_preflight_checks.py
+++ b/bin/cluster/sc_clustering_preflight_checks.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import scanpy as sc
+import numpy as np
+import itertools
+
+parser = argparse.ArgumentParser(
+    description='',
+    formatter_class=argparse.RawTextHelpFormatter
+)
+
+parser.add_argument(
+    "input",
+    type=argparse.FileType('r'),
+    help='Input h5ad file.'
+)
+
+parser.add_argument(
+    "-x", "--method",
+    type=str,
+    action="append",
+    dest="methods",
+    default=None,
+    choices=["leiden", "louvain"],
+    help="Clustering algorithm to check."
+)
+
+parser.add_argument(
+    "-r", "--resolution",
+    type=float,
+    action="append",
+    dest="resolutions",
+    default=None,
+    help="Resolution parameter to check."
+)
+
+parser.add_argument(
+    "-s", "--seed",
+    type=int,
+    action="store",
+    dest="seed",
+    default=0,
+    help="Use this integer seed for reproducibility."
+)
+
+args = parser.parse_args()
+
+# Define the arguments properly
+FILE_PATH_IN = args.input
+
+# I/O
+# Expects h5ad file
+try:
+    adata = sc.read_h5ad(filename=FILE_PATH_IN.name)
+except IOError:
+    raise Exception("VSN ERROR: Can only handle .h5ad files.")
+
+
+def check_neighborhood_graph_exists(adata):
+    if "neighbors" not in adata.uns.keys():
+        raise Exception(
+            "The neighborhood graph of observations has not been computed.")
+
+
+def has_single_cluster(adata, method):
+    num_clusters = len(np.unique(adata.obs[method]))
+    return num_clusters == 1
+
+
+def has_any_singlet_cluster(adata, method):
+    num_cell_by_clusters = adata.obs[method].value_counts()
+    num_singlet_clusters = np.sum(num_cell_by_clusters == 1)
+    return num_singlet_clusters > 0
+
+#
+# Check valid resolution when clustering the data
+#
+
+
+# [('louvain', 0.2), ('louvain', 0.4), ...]
+args_grid = list(itertools.product(args.methods, args.resolutions))
+
+args_valid = []
+args_to_remove = []
+
+print("VSN MSG: Checking valid methods and resolutions... ")
+
+for method, resolution in args_grid:
+    if method.lower() == "louvain":
+        # Run Louvain clustering
+        # Source: https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.tl.louvain.html
+        check_neighborhood_graph_exists(adata=adata)
+        sc.tl.louvain(
+            adata,
+            resolution=resolution,
+            random_state=args.seed
+        )
+
+    elif method.lower() == "leiden":
+        # Run Leiden clustering
+        # Source: https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.tl.leiden.html
+        check_neighborhood_graph_exists(adata=adata)
+        sc.tl.leiden(
+            adata,
+            resolution=resolution,
+            random_state=args.seed
+        )
+    else:
+        raise Exception("VSN ERROR: The given clustering algorithm {} does not exist or is not implemeted.".format(args.method))
+
+    if has_single_cluster(adata=adata, method=method):
+        args_to_remove += [(method, resolution)]
+        continue
+
+    if has_any_singlet_cluster(adata=adata, method=method):
+        args_to_remove += [(method, resolution)]
+        continue
+
+    args_valid += [(method, resolution)]
+
+if len(args_valid) > 0:
+    msg = "\n".join([f'- method: {m}, resolution: {r}'for m, r in args_valid])
+    print(f"VSN MSG: The following arguments are valid: \n\033[92m{msg}\033[0m \033[91m.")
+
+if len(args_to_remove) > 0:
+    msg = "\n".join([f'- method: {m}, resolution: {r}'for m, r in args_to_remove])
+    raise Exception(f"VSN ERROR: The following arguments should be removed from the grid:\n{msg}.")
+else:
+    print("VSN MSG: All preflight clustering checks have passed successfully ")
+
+# I/O
+# None

--- a/bin/filter/sc_cell_gene_filtering.py
+++ b/bin/filter/sc_cell_gene_filtering.py
@@ -115,26 +115,40 @@ def compute_qc_stats(adata, args):
 
 
 def cell_filter(adata, args):
-    #
-    # Filter on min/Max number of counts
-    #
-    if args.min_n_counts > 0:
-        adata = adata[adata.obs['n_counts'] > args.min_n_counts, :]
-    if args.max_n_counts > 0:
-        adata = adata[adata.obs['n_counts'] < args.max_n_counts, :]
-    #
-    # Filter on min/Max number of genes
-    #
-    if args.min_n_genes > 0:
-        sc.pp.filter_cells(adata, min_genes=args.min_n_genes)
-    if args.max_n_genes > 0:
-        adata = adata[adata.obs['n_genes'] < args.max_n_genes, :]
-    #
-    # Filter on percentage of mitochondrial genes
-    #
-    if args.max_percent_mito > 0:
-        adata = adata[adata.obs['percent_mito'] < args.max_percent_mito, :]
-    return adata
+    if args.cell_filter_strategy == "fixedthresholds":
+        print("Applying cell filter fixed thresholds strategy...")
+        #
+        # Filter on min/Max number of counts
+        #
+        if args.min_n_counts > 0:
+            print("Filtering cells by min. number of counts threshold...")
+            print(f"Before filter: {adata.shape[0]}")
+            adata = adata[adata.obs['n_counts'] > args.min_n_counts, :]
+            print(f"After filter: {adata.shape[0]}")
+        if args.max_n_counts > 0:
+            print("Filtering cells by max. number of counts threshold...")
+            print(f"Before filter: {adata.shape[0]}")
+            adata = adata[adata.obs['n_counts'] < args.max_n_counts, :]
+            print(f"After filter: {adata.shape[0]}")
+        #
+        # Filter on min/Max number of genes
+        #
+        if args.min_n_genes > 0:
+            print("Filtering cells by min. number of genes threshold...")
+            print(f"Before filter: {adata.shape[0]}")
+            sc.pp.filter_cells(adata, min_genes=args.min_n_genes)
+            print(f"After filter: {adata.shape[0]}")
+        if args.max_n_genes > 0:
+            print("Filtering cells by max. number of genes threshold...")
+            print(f"Before filter: {adata.shape[0]}")
+            adata = adata[adata.obs['n_genes'] < args.max_n_genes, :]
+            print(f"After filter: {adata.shape[0]}")
+        #
+        # Filter on percentage of mitochondrial genes
+        #
+        if args.max_percent_mito > 0:
+            adata = adata[adata.obs['percent_mito'] < args.max_percent_mito, :]
+        return adata
 
 
 def gene_filter(adata, args):

--- a/bin/reports/sc_filter_qc_report.ipynb
+++ b/bin/reports/sc_filter_qc_report.ipynb
@@ -95,6 +95,10 @@
     "            ax1.axvline(x=adata.uns['sc']['scanpy']['filter']['cellFilterMinNGenes'], ymin=0,ymax=1, color='red')\n",
     "        if not adata.uns['sc']['scanpy']['filter']['cellFilterMaxNGenes'] == -1:\n",
     "            ax1.axvline(x=adata.uns['sc']['scanpy']['filter']['cellFilterMaxNGenes'], ymin=0,ymax=1, color='red')\n",
+    "        if not adata.uns['sc']['scanpy']['filter']['cellFilterMinNCounts'] == -1:\n",
+    "            ax2.axvline(x=adata.uns['sc']['scanpy']['filter']['cellFilterMinNCounts'], ymin=0,ymax=1, color='red')\n",
+    "        if not adata.uns['sc']['scanpy']['filter']['cellFilterMaxNCounts'] == -1:\n",
+    "            ax2.axvline(x=adata.uns['sc']['scanpy']['filter']['cellFilterMaxNCounts'], ymin=0,ymax=1, color='red')\n",
     "        if not adata.uns['sc']['scanpy']['filter']['geneFilterMinNCells'] == -1:\n",
     "            ax4.axvline(x=adata.uns['sc']['scanpy']['filter']['geneFilterMinNCells']-0.5, ymin=0,ymax=1, color='red')\n",
     "\n",
@@ -335,6 +339,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(adata_pre.uns['sc']['scanpy']['filter'])"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -364,7 +377,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Filter 2: Fraction of mitochondrial reads per cell\n",
+    "### Filter 2: Number of counts expressed per cell\n",
+    "\n",
+    "**Cell-level filtering**\n",
+    "\n",
+    "To determine whether the thresholds are set correctly, it's useful to look at a histogram showing the distribution of the number of genes expressed for each cell. Here, the entire range of the data (equivalent to the summary plot above) is shown on a wide x-axis. The current thresholds are show in red lines (it's possible that one or both thresholds are outside the plot limits; in this case the threshold should likely be raised/lowered to better fit the data)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thr = [ adata_pre.uns['sc']['scanpy']['filter']['cellFilterMinNCounts'],\n",
+    "        adata_pre.uns['sc']['scanpy']['filter']['cellFilterMaxNCounts'] ]\n",
+    "plotSingleDiagnosticHist(adata_pre.obs['n_counts'],\n",
+    "                         xlab='Number of counts expressed per cell',\n",
+    "                         filter_thr=thr)\n",
+    "print(\"Number of counts expressed per cell threshold is set to {}-{}\".format(thr[0],thr[1]))\n",
+    "print(\"Unfiltered data range is {}-{}.\".format(adata_pre.obs['n_counts'].min(),adata_pre.obs['n_counts'].max() ))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Filter 3: Fraction of mitochondrial reads per cell\n",
     "\n",
     "**Cell-level filtering**\n",
     "\n",
@@ -392,7 +431,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Filter 3: Number of cells expressing each gene\n",
+    "### Filter 4: Number of cells expressing each gene\n",
     "\n",
     "**Gene-level filtering**\n",
     "\n",

--- a/conf/base.config
+++ b/conf/base.config
@@ -39,6 +39,7 @@ params {
                 }
             }
             clustering {
+                preflight_checks = true
                 report_ipynb = "${params.misc.test.enabled ? '../../..' : ''}/src/scanpy/bin/reports/sc_clustering_report.ipynb"
                 method = 'louvain' 
                 resolution = 0.8 

--- a/conf/filter.config
+++ b/conf/filter.config
@@ -3,6 +3,7 @@ params {
         scanpy {
             filter {
                 report_ipynb = "${params.misc.test.enabled ? '../../..' : ''}/src/scanpy/bin/reports/sc_filter_qc_report.ipynb"
+                cellFilterStrategy = "fixedthresholds"
                 cellFilterMinNGenes = 200
                 cellFilterMaxNGenes = 4000
                 //cellFilterMinNCounts = ''

--- a/main.nf
+++ b/main.nf
@@ -10,15 +10,17 @@ import static groovy.json.JsonOutput.*
 include { 
     INIT;
     getDataChannel;
-} from './src/utils/workflows/utils' params(params)
+} from '../utils/workflows/utils' params(params)
 INIT(params)
 include {
     SC__FILE_CONVERTER
-} from './src/utils/processes/utils' params(params)
+} from '../utils/processes/utils' params(params)
 include {
     getDataChannel
-} from './src/channels/channels' params(params)
-
+} from '../channels/channels' params(params)
+include {
+    QC_FILTER;
+} from './workflows/qc_filter.nf' params(params)
 include {
     SINGLE_SAMPLE
 } from './workflows/single_sample.nf' params(params)
@@ -31,5 +33,14 @@ workflow single_sample {
         getDataChannel | \
             SC__FILE_CONVERTER | \
             SINGLE_SAMPLE
+
+}
+
+workflow single_sample_qc {
+
+    main:
+        getDataChannel | \
+            SC__FILE_CONVERTER | \
+            QC_FILTER
 
 }

--- a/processes/cluster.nf
+++ b/processes/cluster.nf
@@ -19,6 +19,7 @@ class SC__SCANPY__CLUSTERING_PARAMS {
 	String iff = null;
 	String off = null;
 	String report_ipynb = null;
+	boolean preflight_checks = null;
 	// Parameters benchmarkable
 	String method = null; ArrayList<String> methods = null;
     Float resolution = null; ArrayList<Float> resolutions = null;
@@ -84,6 +85,36 @@ class SC__SCANPY__CLUSTERING_PARAMS {
 		displayMessage(tag)
 		return $method.combine($resolution)
 	}
+
+}
+
+process SC__SCANPY__CLUSTERING_PREFLIGHT_CHECKS {
+
+	container params.sc.scanpy.container
+	label 'compute_resources__mem'
+
+	input:
+    	tuple \
+			val(sampleId), \
+			path(f)
+
+	output:
+		tuple \
+			val(sampleId), \
+			path(f)
+
+  	script:
+		def sampleParams = params.parseConfig(sampleId, params.global, params.sc.scanpy.clustering)
+		processParams = sampleParams.local
+		methodAsArguments = processParams?.methods ? processParams.methods.collect({ '--method' + ' ' + it }).join(' ') : '--method ' + processParams.method
+		resolutionAsArguments = processParams?.resolutions ? processParams?.resolutions.collect({ '--resolution' + ' ' + it }).join(' ') : '--resolution ' + processParams.resolution
+		"""
+		${binDir}/cluster/sc_clustering_preflight_checks.py \
+			--seed ${params.global.seed} \
+			${methodAsArguments} \
+			${resolutionAsArguments} \
+			$f \
+		"""
 
 }
 

--- a/processes/filter.nf
+++ b/processes/filter.nf
@@ -7,6 +7,7 @@ binDir = !params.containsKey("test") ? "${workflow.projectDir}/src/scanpy/bin" :
 process SC__SCANPY__COMPUTE_QC_STATS {
 
   	container params.sc.scanpy.container
+    publishDir "${params.global.outdir}/data/intermediate", mode: 'symlink', overwrite: true
     label 'compute_resources__mem'
 
   	input:

--- a/processes/filter.nf
+++ b/processes/filter.nf
@@ -24,12 +24,13 @@ process SC__SCANPY__COMPUTE_QC_STATS {
             compute \
             $f \
             ${sampleId}.SC__SCANPY__COMPUTE_QC_STATS.${processParams.off} \
-            ${(processParams.containsKey('cellFilterMinNCounts')) ? '--min-n-counts ' + processParams.cellFilterMinNCounts : ''} \
-            ${(processParams.containsKey('cellFilterMaxNCounts')) ? '--max-n-counts ' + processParams.cellFilterMaxNCounts : ''} \
-            ${(processParams.containsKey('cellFilterMinNGenes')) ? '--min-n-genes ' + processParams.cellFilterMinNGenes : ''} \
-            ${(processParams.containsKey('cellFilterMaxNGenes')) ? '--max-n-genes ' + processParams.cellFilterMaxNGenes : ''} \
-            ${(processParams.containsKey('cellFilterMaxPercentMito')) ? '--max-percent-mito ' + processParams.cellFilterMaxPercentMito : ''} \
-            ${(processParams.containsKey('geneFilterMinNCells')) ? '--min-number-cells ' + processParams.geneFilterMinNCells : ''}
+            ${processParams?.cellFilterStrategy ? '--cell-filter-strategy ' + processParams.cellFilterStrategy : ''} \
+            ${processParams?.cellFilterMinNCounts ? '--min-n-counts ' + processParams.cellFilterMinNCounts : ''} \
+            ${processParams?.cellFilterMaxNCounts ? '--max-n-counts ' + processParams.cellFilterMaxNCounts : ''} \
+            ${processParams?.cellFilterMinNGenes ? '--min-n-genes ' + processParams.cellFilterMinNGenes : ''} \
+            ${processParams?.cellFilterMaxNGenes ? '--max-n-genes ' + processParams.cellFilterMaxNGenes : ''} \
+            ${processParams?.cellFilterMaxPercentMito ? '--max-percent-mito ' + processParams.cellFilterMaxPercentMito : ''} \
+            ${processParams?.geneFilterMinNCells ? '--min-number-cells ' + processParams.geneFilterMinNCells : ''}
         """
 
 }
@@ -55,7 +56,7 @@ process SC__SCANPY__GENE_FILTER {
             genefilter \
             $f \
             ${sampleId}.SC__SCANPY__GENE_FILTER.${processParams.off} \
-            ${(processParams.containsKey('geneFilterMinNCells')) ? '--min-number-cells ' + processParams.geneFilterMinNCells : ''}
+            ${processParams?.geneFilterMinNCells ? '--min-number-cells ' + processParams.geneFilterMinNCells : ''}
         """
 
 }
@@ -81,11 +82,12 @@ process SC__SCANPY__CELL_FILTER {
             cellfilter \
             $f \
             ${sampleId}.SC__SCANPY__CELL_FILTER.${processParams.off} \
-            ${(processParams.containsKey('cellFilterMinNCounts')) ? '--min-n-counts ' + processParams.cellFilterMinNCounts : ''} \
-            ${(processParams.containsKey('cellFilterMaxNCounts')) ? '--max-n-counts ' + processParams.cellFilterMaxNCounts : ''} \
-            ${(processParams.containsKey('cellFilterMinNGenes')) ? '--min-n-genes ' + processParams.cellFilterMinNGenes : ''} \
-            ${(processParams.containsKey('cellFilterMaxNGenes')) ? '--max-n-genes ' + processParams.cellFilterMaxNGenes : ''} \
-            ${(processParams.containsKey('cellFilterMaxPercentMito')) ? '--max-percent-mito ' + processParams.cellFilterMaxPercentMito : ''}
+            ${processParams?.cellFilterStrategy ? '--cell-filter-strategy ' + processParams.cellFilterStrategy : ''} \
+            ${processParams?.cellFilterMinNCounts ? '--min-n-counts ' + processParams.cellFilterMinNCounts : ''} \
+            ${processParams?.cellFilterMaxNCounts ? '--max-n-counts ' + processParams.cellFilterMaxNCounts : ''} \
+            ${processParams?.cellFilterMinNGenes ? '--min-n-genes ' + processParams.cellFilterMinNGenes : ''} \
+            ${processParams?.cellFilterMaxNGenes ? '--max-n-genes ' + processParams.cellFilterMaxNGenes : ''} \
+            ${processParams?.cellFilterMaxPercentMito ? '--max-percent-mito ' + processParams.cellFilterMaxPercentMito : ''}
         """
 
 }

--- a/processes/regress_out.nf
+++ b/processes/regress_out.nf
@@ -23,6 +23,9 @@ process SC__SCANPY__REGRESS_OUT {
 		processParams = sampleParams.local
 		variablesToRegressOutAsArguments = processParams.variablesToRegressOut.collect({ '--variable-to-regress-out' + ' ' + it }).join(' ')
 		"""
+		export MKL_NUM_THREADS=1
+		export NUMEXPR_NUM_THREADS=1
+		export OMP_NUM_THREADS=1
 		${binDir}adjust/sc_regress_out.py \
 			${(processParams.containsKey('method')) ? '--method ' + processParams.method : ''} \
 			${(processParams.containsKey('variablesToRegressOut')) ? variablesToRegressOutAsArguments : ''} \

--- a/processes/regress_out.nf
+++ b/processes/regress_out.nf
@@ -6,13 +6,17 @@ process SC__SCANPY__REGRESS_OUT {
 
 	container params.sc.scanpy.container
 	publishDir "${params.global.outdir}/data/intermediate", mode: 'symlink', overwrite: true
-    label 'compute_resources__mem'
+    label 'compute_resources__cpu'
 
 	input:
-		tuple val(sampleId), path(f)
+		tuple \
+			val(sampleId), \
+			path(f)
 
 	output:
-		tuple val(sampleId), path("${sampleId}.SC__SCANPY__REGRESS_OUT.${processParams.off}")
+		tuple \
+			val(sampleId), \
+			path("${sampleId}.SC__SCANPY__REGRESS_OUT.${processParams.off}")
 
 	script:
 		def sampleParams = params.parseConfig(sampleId, params.global, params.sc.scanpy.regress_out)
@@ -22,6 +26,7 @@ process SC__SCANPY__REGRESS_OUT {
 		${binDir}adjust/sc_regress_out.py \
 			${(processParams.containsKey('method')) ? '--method ' + processParams.method : ''} \
 			${(processParams.containsKey('variablesToRegressOut')) ? variablesToRegressOutAsArguments : ''} \
+			--n-jobs ${task.cpus} \
 			$f \
 			"${sampleId}.SC__SCANPY__REGRESS_OUT.${processParams.off}"
 		"""

--- a/workflows/single_sample.nf
+++ b/workflows/single_sample.nf
@@ -22,6 +22,9 @@ include {
 include {
     FILE_CONVERTER;
 } from '../../utils/workflows/fileConverter.nf' params(params)
+include {
+    FILTER_AND_ANNOTATE_AND_CLEAN;
+} from '../../utils/workflows/filterAnnotateClean.nf' params(params)
 
 ////////////////////////////////////////////////////////
 //  Import sub-workflows/processes from the tool module:
@@ -67,9 +70,11 @@ workflow SINGLE_SAMPLE {
         data
 
     main:
-        // Process the data
+        // Prefilter the data
+        out = FILTER_AND_ANNOTATE_AND_CLEAN( data )
+
         filtered = params.sc.scanpy.containsKey("filter") 
-            ? QC_FILTER( data ).filtered : data
+            ? out = QC_FILTER( out ).filtered : out
         transformed_normalized = params.sc.scanpy.containsKey("data_transformation") \
             && params.sc.scanpy.containsKey("normalization")
             ? NORMALIZE_TRANSFORM( filtered ) : filtered

--- a/workflows/single_sample.nf
+++ b/workflows/single_sample.nf
@@ -73,10 +73,8 @@ workflow SINGLE_SAMPLE {
         // Prefilter the data
         out = FILTER_AND_ANNOTATE_AND_CLEAN( data )
 
-        filtered = params.sc.scanpy.containsKey("filter") 
-            ? out = QC_FILTER( out ).filtered : out
-        transformed_normalized = params.sc.scanpy.containsKey("data_transformation") \
-            && params.sc.scanpy.containsKey("normalization")
+        filtered = params.sc.scanpy?.filter ? QC_FILTER( out ).filtered : out
+        transformed_normalized = params.sc.scanpy?.data_transformation && params.sc.scanpy?.normalization
             ? NORMALIZE_TRANSFORM( filtered ) : filtered
         out = HVG_SELECTION( transformed_normalized )
         DIM_REDUCTION_PCA( out.scaled )
@@ -98,7 +96,7 @@ workflow SINGLE_SAMPLE {
         ipynbs = COMBINE_REPORTS(
             samples,
             UTILS__GENERATE_WORKFLOW_CONFIG_REPORT.out,
-            params.sc.scanpy.containsKey("filter") ? QC_FILTER.out.report : Channel.empty(),
+            params.sc.scanpy?.filter ? QC_FILTER.out.report : Channel.empty(),
             HVG_SELECTION.out.report,
             DIM_REDUCTION_TSNE_UMAP.out.report,
             CLUSTER_IDENTIFICATION.out.report
@@ -112,9 +110,11 @@ workflow SINGLE_SAMPLE {
         )
         SC__SCANPY__REPORT_TO_HTML(SC__SCANPY__MERGE_REPORTS.out)
 
+
+
         // Finalize
         FINALIZE(
-            params.sc?.filter ? QC_FILTER.out.filtered : data,
+            params.sc.scanpy?.filter ? QC_FILTER.out.filtered : data,
             CLUSTER_IDENTIFICATION.out.marker_genes,
             'SINGLE_SAMPLE.final_output'
         )
@@ -133,7 +133,7 @@ workflow SINGLE_SAMPLE {
         )
 
     emit:
-        filtered_data = params.sc.scanpy.containsKey("filter") ? QC_FILTER.out.filtered : Channel.empty()
+        filtered_data = params.sc.scanpy?.filter ? QC_FILTER.out.filtered : Channel.empty()
         filtered_loom = FINALIZE.out.filteredloom
         hvg_data = HVG_SELECTION.out.hvg
         dr_pca_data = DIM_REDUCTION_PCA.out

--- a/workflows/single_sample.nf
+++ b/workflows/single_sample.nf
@@ -67,10 +67,10 @@ workflow SINGLE_SAMPLE {
         // Process the data
         filtered = params.sc.scanpy.containsKey("filter") 
             ? QC_FILTER( data ).filtered : data
-        out = params.sc.scanpy.containsKey("data_transformation") \
-            && params.sc.scanpy.containsKey("normalization") 
+        transformed_normalized = params.sc.scanpy.containsKey("data_transformation") \
+            && params.sc.scanpy.containsKey("normalization")
             ? NORMALIZE_TRANSFORM( filtered ) : filtered
-        out = HVG_SELECTION( out )
+        out = HVG_SELECTION( transformed_normalized )
         DIM_REDUCTION_PCA( out.scaled )
         NEIGHBORHOOD_GRAPH( DIM_REDUCTION_PCA.out )
         DIM_REDUCTION_TSNE_UMAP( NEIGHBORHOOD_GRAPH.out )

--- a/workflows/single_sample.nf
+++ b/workflows/single_sample.nf
@@ -67,11 +67,11 @@ workflow SINGLE_SAMPLE {
         // Process the data
         filtered = params.sc.scanpy.containsKey("filter") 
             ? QC_FILTER( data ).filtered : data
-        transformed_normalized = params.sc.scanpy.containsKey("data_transformation") \
+        out = params.sc.scanpy.containsKey("data_transformation") \
             && params.sc.scanpy.containsKey("normalization") 
             ? NORMALIZE_TRANSFORM( filtered ) : filtered
-        out = HVG_SELECTION( transformed_normalized )
-        DIM_REDUCTION_PCA( out )
+        out = HVG_SELECTION( out )
+        DIM_REDUCTION_PCA( out.scaled )
         NEIGHBORHOOD_GRAPH( DIM_REDUCTION_PCA.out )
         DIM_REDUCTION_TSNE_UMAP( NEIGHBORHOOD_GRAPH.out )
         CLUSTER_IDENTIFICATION(

--- a/workflows/single_sample.nf
+++ b/workflows/single_sample.nf
@@ -14,6 +14,9 @@ include {
     PUBLISH;
 } from '../../utils/workflows/utils.nf' params(params)
 include {
+    FINALIZE;
+} from '../../utils/workflows/finalize.nf' params(params)
+include {
     SC__H5AD_TO_FILTERED_LOOM;
 } from '../../utils/processes/h5adToLoom.nf' params(params)
 include {


### PR DESCRIPTION
- Add logs to display number of cells after each filter b5cdfb4
Add new cell filter strategy 'adaptivethresholds' based on the MAD of the QC metrics distributions (in log space) Closes #47 19ced87
- Disable BLAS multithreading to reduce cpu usage (especially if n_jobs is > 1) 547d58f
- Add clustering preflight checks Closes #48
- Add plots for the n_counts filter in filter QC report python notebook 71548bf
- Don't let QC_FILTER handle any pre-filter or annotation of the data. Let this be handled by the parent workflows. This option is better especially when when don't what to perform the basic filtering but want to annotate the data. c67d48b
- Bug fixes 6159414 222d89e a4601a4 3f3d28f 756437a